### PR TITLE
fix : Docker issue around certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,11 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -installsuffix cgo -o /bin/go-play-publisher cmd/gpp/main.go
 
 # Thin stage
-FROM scratch
+FROM alpine:3.11.3
+RUN apk add --no-cache ca-certificates openssl
+
 ENV PATH=/bin
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /bin/go-play-publisher /bin/go-play-publisher
 

--- a/cmd/gpp/main.go
+++ b/cmd/gpp/main.go
@@ -80,7 +80,6 @@ func getFlags() []cli.Flag {
 }
 
 func actionListApk(c *cli.Context) error {
-	fmt.Println("actionListApk")
 	client, err := playpublisher.NewClient(serviceAccountFilePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add `ca-certificates` and `openssl` package to the Docker image to be
able to invoke the Google API